### PR TITLE
Controller plugin argument 2 is not required.

### DIFF
--- a/src/Mail/Controller/Plugin/Email.php
+++ b/src/Mail/Controller/Plugin/Email.php
@@ -68,7 +68,7 @@ class Email extends AbstractPlugin
      * @param  Message|null $message
      * @return void
      */
-    public function __invoke(array $options, array $variables, Message $message = null)
+    public function __invoke(array $options, array $variables = array(), Message $message = null)
     {
         $this->getService()->send($options, $variables, $message);
     }


### PR DESCRIPTION
Controller plug proxies to service but argument requirements are more restrictive and I don't see why we need to pass an empty array in as the second argument to make it work?
