### PR TITLE
Enable Multipart Alternative content-Type

### DIFF
--- a/src/Service/MailService.php
+++ b/src/Service/MailService.php
@@ -200,6 +200,7 @@ class MailService implements MailServiceInterface
         $body->setParts(array($textPart, $htmlPart));
 
         $message->setBody($body);
+        $message->getHeaders()->get('content-type')->setType('multipart/alternative');
     }
 
     /**


### PR DESCRIPTION
Enable the Multipart Alternative content-Type when HTML template and TEXT template are used together.

The default headers configuration doesn't worked.

$mailer->send(array(
            'to'       => $recipient,
            'subject'  => $subject,
            'template' => 'email/template_html',
            'template_text' => 'email/template_text',
            'headers'  => array(
                'content-type' => 'multipart/alternative' // not working
            ),
        ), array(
            'var' => $var
        ));
